### PR TITLE
Add with_mock function for convenient mocking with use sugar

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ Don't forget to unload all mocks after each test case.
 
 Further documentation can be found at <https://hexdocs.pm/mockth>.
 
+### With `use` sugar
+The `with_mock` function is available to use mockth in your tests with the `use` sugar. It performs all steps from the example above (mock, validate, assert module is mocked), and even unloads all mocks after the test function finishes.
+
+```gleam
+ pub fn with_mock_test() {
+  use mock <- mockth.with_mock(
+    module: "gleam@function",
+    function: "identity",
+    replacement: fn(_) { "hello" },
+  )
+
+  function.identity("world")
+  |> should.equal("hello")
+
+  // the mocked module is available here as `mocks`
+  // for example to be able to call `mockth.history` with it.
+}
+```
+
 ## Development
 
 ```sh

--- a/gleam.toml
+++ b/gleam.toml
@@ -8,6 +8,4 @@ repository = { type = "github", user = "bondiano", repo = "mockth" }
 gleam_stdlib = "~> 0.34 or ~> 1.0"
 meck = "~> 0.9"
 gleam_erlang = "~> 0.25"
-
-[dev-dependencies]
 gleeunit = "~> 1.0"

--- a/test/mockth_test.gleam
+++ b/test/mockth_test.gleam
@@ -22,3 +22,23 @@ pub fn expect_test() {
 
   mockth.unload_all()
 }
+
+pub fn with_mock_test() {
+  use _mock <- mockth.with_mock(
+    module: "gleam@function",
+    function: "identity",
+    replacement: fn(_) { "hello" },
+  )
+
+  function.identity("world")
+  |> should.equal("hello")
+}
+
+pub fn with_mock_assert_unload_test() {
+  mockth.with_mock("gleam@function", "identity", fn(_) { "hello" }, fn(_) {
+    Nil
+  })
+
+  mockth.mocked()
+  |> should.equal([])
+}


### PR DESCRIPTION
As discussed on the Gleam discord, this PR adds a utility function so mocking is less verbose with `use` sugar.