### PR TITLE
Updating Erlang depency -> 1.0.0=> ( Latest version: 1.3.0)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "27.0"
-          gleam-version: "1.9.1"
+          gleam-version: "1.11.0"
           rebar3-version: "3.23.0"
 
       - name: Install Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "27.0"
-          gleam-version: "1.11.0"
+          gleam-version: "1.12.0"
           rebar3-version: "3.23.0"
 
       - name: Install Dependencies

--- a/gleam.toml
+++ b/gleam.toml
@@ -10,5 +10,5 @@ target = "erlang"
 [dependencies]
 gleam_stdlib = ">= 0.52.0 and < 1.0.0"
 meck = "1.0.0"
-gleam_erlang = ">= 0.33.0 and < 1.0.0"
+gleam_erlang = ">= 1.0.0 and < 2.0.0"
 gleeunit = ">= 1.2.0 and < 2.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_erlang", version = "0.34.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "0C38F2A128BAA0CEF17C3000BD2097EB80634E239CE31A86400C4416A5D0FDCC" },
-  { name = "gleam_stdlib", version = "0.57.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "86EFACDF6460B8681E82752C5490F9630EC0F138F88A037DDCB241799AA8811F" },
-  { name = "gleeunit", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "0E6C83834BA65EDCAAF4FE4FB94AC697D9262D83E6F58A750D63C9F6C8A9D9FF" },
+  { name = "gleam_erlang", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "1124AD3AA21143E5AF0FC5CF3D9529F6DB8CA03E43A55711B60B6B7B3874375C" },
+  { name = "gleam_stdlib", version = "0.63.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "E1D5EC07638F606E48F0EA1556044DD805F2ACE9092A6F6AFBE4A0CC4DA21C2F" },
+  { name = "gleeunit", version = "1.6.1", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "FDC68A8C492B1E9B429249062CD9BAC9B5538C6FBF584817205D0998C42E1DAC" },
   { name = "meck", version = "1.0.0", build_tools = ["rebar3"], requirements = [], otp_app = "meck", source = "hex", outer_checksum = "680A9BCFE52764350BEB9FB0335FB75FEE8E7329821416CEE0A19FEC35433882" },
 ]
 
 [requirements]
-gleam_erlang = { version = ">= 0.33.0 and < 1.0.0" }
+gleam_erlang = { version = ">= 1.0.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.52.0 and < 1.0.0" }
 gleeunit = { version = ">= 1.2.0 and < 2.0.0" }
 meck = { version = "1.0.0" }


### PR DESCRIPTION
To make these changes we have to make some code changes as well:

- `result.then` is deprecated and replaced with `result.try` (though all instances of this has been removed as we don't really need it any more)
- `atom.from_string` -> `atom.create`: There's no longer a `from_string" function, and 'create` does not return a `Result`. Therefore, a lot of the error handling is no longer needed, which also simplifies a lot of the code.

Fixes #5 

